### PR TITLE
Send query params for /lists/{list_id}/merge-fields endpoint

### DIFF
--- a/lists.go
+++ b/lists.go
@@ -533,6 +533,15 @@ type MergeFieldsParams struct {
 	Required bool   `json:"required"`
 }
 
+func (p MergeFieldsParams) Params() map[string]string {
+	m := p.ExtendedQueryParams.Params()
+	m["type"] = p.Type
+	if p.Required {
+		m["required"] = "true"
+	}
+	return m
+}
+
 type MergeFieldParams struct {
 	BasicQueryParams
 


### PR DESCRIPTION
Make sure type & required values are serialized to query params.

```
2017/09/13 11:41:24 Adding query params: map["type":["radio"] "count":["100"] "offset":["0"] "required":["1"]]
```