### PR TITLE
Add NewListResponse function

### DIFF
--- a/lists.go
+++ b/lists.go
@@ -132,6 +132,17 @@ func (api API) GetLists(params *ListQueryParams) (*ListOfLists, error) {
 	return response, nil
 }
 
+// NewListResponse returns a *ListResponse that is minimally viable for making
+// API requests. This is useful for such API requests that depend on a
+// ListResponse for its ID (e.g. CreateMember) without having to make a second
+// network request to get the list itself.
+func (api API) NewListResponse(id string) *ListResponse {
+	return &ListResponse{
+		ID:  id,
+		api: &api,
+	}
+}
+
 func (api API) GetList(id string, params *BasicQueryParams) (*ListResponse, error) {
 	endpoint := fmt.Sprintf(single_list_path, id)
 

--- a/members.go
+++ b/members.go
@@ -142,6 +142,18 @@ func (list ListResponse) UpdateMember(id string, body *MemberRequest) (*Member, 
 	return response, list.api.Request("PATCH", endpoint, nil, body, response)
 }
 
+func (list ListResponse) AddOrUpdateMember(id string, body *MemberRequest) (*Member, error) {
+	if err := list.CanMakeRequest(); err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf(single_member_path, list.ID, id)
+	response := new(Member)
+	response.api = list.api
+
+	return response, list.api.Request("PUT", endpoint, nil, body, response)
+}
+
 func (list ListResponse) DeleteMember(id string) (bool, error) {
 	if err := list.CanMakeRequest(); err != nil {
 		return false, err


### PR DESCRIPTION
`NewListResponse` returns a `*ListResponse` that is minimally viable for making API requests. This is useful for such API requests that depend on a ListResponse for its ID (e.g. CreateMember) without having to make a second network request to get the list itself.

**EDIT:** I also added support for the `PUT` method listed [here](https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#) (`PUT /lists/{list_id}/members/{subscriber_hash}`)