### PR TITLE
Merge fields are not always strings

### DIFF
--- a/members.go
+++ b/members.go
@@ -24,14 +24,14 @@ type ListOfMembers struct {
 }
 
 type MemberRequest struct {
-	EmailAddress string            `json:"email_address"`
-	Status       string            `json:"status"`
-	StatusIfNew  string            `json:"status_if_new,omitempty"`
-	MergeFields  map[string]string `json:"merge_fields,omitempty"`
-	Interests    map[string]bool   `json:"interests,omitempty"`
-	Language     string            `json:"language"`
-	VIP          bool              `json:"vip"`
-	Location     *MemberLocation   `json:"location,omitempty"`
+	EmailAddress string                 `json:"email_address"`
+	Status       string                 `json:"status"`
+	StatusIfNew  string                 `json:"status_if_new,omitempty"`
+	MergeFields  map[string]interface{} `json:"merge_fields,omitempty"`
+	Interests    map[string]bool        `json:"interests,omitempty"`
+	Language     string                 `json:"language"`
+	VIP          bool                   `json:"vip"`
+	Location     *MemberLocation        `json:"location,omitempty"`
 }
 
 type Member struct {


### PR DESCRIPTION
According to [the MailChimp documentation](https://developer.mailchimp.com/documentation/mailchimp/reference/lists/merge-fields/), merge fields can be one of a number of different data types. While most can be parsed as strings, number merge fields definitely cannot. Any request that returns a `MemberRequest` (e.g. `AddOrUpdateMember()`) with a merge field of type `number` will produce the JSON unmarshaling error `json: cannot unmarshal number into Go value of type string`.

A better solution than the one presented here would be to create a `MergeField` type with a custom JSON unmarshaling function that uses type assertions or a regular expression to determine the type of the field. This commit is just a temporary fix. It does, however, address the immediate problem.