### PR TITLE
Add errors array to APIError for field validation errors from list.CreateMember()

### DIFF
--- a/common_types.go
+++ b/common_types.go
@@ -12,11 +12,16 @@ type APIError struct {
 	Status   int    `json:"status,omitempty"`
 	Detail   string `json:"detail,omitempty"`
 	Instance string `json:"instance,omitempty"`
+	Errors   []struct {
+		Field   string `json:"field"`
+		Message string `json:"message"`
+	} `json:"errors,omitempty"`
 }
 
 func (err APIError) String() string {
-	return fmt.Sprintf("%d : %s : %s : %s", err.Status, err.Type, err.Title, err.Detail)
+	return fmt.Sprintf("%d : %s : %s : %s : %s", err.Status, err.Type, err.Title, err.Detail, err.Errors)
 }
+
 func (err APIError) Error() string {
 	return err.String()
 }


### PR DESCRIPTION
This should fix #1 
Not sure if this will solve all error cases for all APIs, but this worked for a case where list.CreateMember() was providing the detailed error message, but I couldn't see it with the current APIError struct.