### PR TITLE
Update lists.go

### DIFF
--- a/lists.go
+++ b/lists.go
@@ -463,7 +463,7 @@ type InterestRequest struct {
 	DisplayOrder int    `json:"display_order"`
 }
 
-func (list ListResponse) GetInterests(interestCategoryID string, params *BasicQueryParams) (*ListOfInterests, error) {
+func (list ListResponse) GetInterests(interestCategoryID string, params *ExtendedQueryParams) (*ListOfInterests, error) {
 	if err := list.CanMakeRequest(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
GetInterests should accept ExtendedQueryParams instead of BasicQueryParams
https://github.com/hanzoai/gochimp3/issues/22