### PR TITLE
Update structure MemberNoteShort

### DIFF
--- a/members.go
+++ b/members.go
@@ -80,7 +80,7 @@ type MemberLocation struct {
 }
 
 type MemberNoteShort struct {
-	ID        string `json:"note_id"`
+	ID        int    `json:"note_id"`
 	CreatedAt string `json:"created_at"`
 	CreatedBy string `json:"created_by"`
 	Note      string `json:"note"`


### PR DESCRIPTION
Actually MemberNoteShort looks like this:
      "last_note": {
        "note_id": 66847,
        "created_at": "2018-05-18T18:47:24+00:00",
        "created_by": "87889782",
        "note": "Subscribed via Builder."
      },
note_id is NOT string