### PR TITLE
Add missing fields to MemberRequest

### DIFF
--- a/members.go
+++ b/members.go
@@ -24,31 +24,32 @@ type ListOfMembers struct {
 }
 
 type MemberRequest struct {
-	EmailAddress string                 `json:"email_address"`
-	Status       string                 `json:"status"`
-	StatusIfNew  string                 `json:"status_if_new,omitempty"`
-	MergeFields  map[string]interface{} `json:"merge_fields,omitempty"`
-	Interests    map[string]bool        `json:"interests,omitempty"`
-	Language     string                 `json:"language"`
-	VIP          bool                   `json:"vip"`
-	Location     *MemberLocation        `json:"location,omitempty"`
+	EmailAddress    string                 `json:"email_address"`
+	Status          string                 `json:"status"`
+	StatusIfNew     string                 `json:"status_if_new,omitempty"`
+	MergeFields     map[string]interface{} `json:"merge_fields,omitempty"`
+	Interests       map[string]bool        `json:"interests,omitempty"`
+	Language        string                 `json:"language"`
+	VIP             bool                   `json:"vip"`
+	Location        *MemberLocation        `json:"location,omitempty"`
+	IPOpt           string                 `json:"ip_opt,omitempty"`
+	IPSignup        string                 `json:"ip_signup,omitempty"`
+	TimestampSignup string                 `json:"timestamp_signup,omitempty"`
+	TimestampOpt    string                 `json:"timestamp_opt,omitempty"`
 }
 
 type Member struct {
 	MemberRequest
 
-	ID              string          `json:"id"`
-	ListID          string          `json:"list_id"`
-	UniqueEmailID   string          `json:"unique_email_id"`
-	EmailType       string          `json:"email_type"`
-	Stats           MemberStats     `json:"stats"`
-	IPSignup        string          `json:"ip_signup"`
-	TimestampSignup string          `json:"timestamp_signup"`
-	TimestampOpt    string          `json:"timestamp_opt"`
-	MemberRating    int             `json:"member_rating"`
-	LastChanged     string          `json:"last_changed"`
-	EmailClient     string          `json:"email_client"`
-	LastNote        MemberNoteShort `json:"last_note"`
+	ID            string          `json:"id"`
+	ListID        string          `json:"list_id"`
+	UniqueEmailID string          `json:"unique_email_id"`
+	EmailType     string          `json:"email_type"`
+	Stats         MemberStats     `json:"stats"`
+	MemberRating  int             `json:"member_rating"`
+	LastChanged   string          `json:"last_changed"`
+	EmailClient   string          `json:"email_client"`
+	LastNote      MemberNoteShort `json:"last_note"`
 
 	api *API
 }


### PR DESCRIPTION
This adds the following fields to MemberRequest:

- `IPOpt`
- `IPSignup`
- `TimestampSignup`
- `TimestampOpt`

Some of them were already defined on the `Member` struct which embeds `MemberRequest` and were therefore removed from `Member`.