### PR TITLE
Contact Struct JSON Fix

### DIFF
--- a/api.go
+++ b/api.go
@@ -44,7 +44,7 @@ func New(apiKey string) *API {
 	u.Path = Version
 
 	return &API{
-		User:     "gochimp3",
+		User:     "rnahar@neighborly.com",
 		Key:      apiKey,
 		endpoint: u.String(),
 	}

--- a/api.go
+++ b/api.go
@@ -44,7 +44,7 @@ func New(apiKey string) *API {
 	u.Path = Version
 
 	return &API{
-		User:     "rnahar@neighborly.com",
+		User:     "gochimp3",
 		Key:      apiKey,
 		endpoint: u.String(),
 	}

--- a/common_types.go
+++ b/common_types.go
@@ -139,7 +139,7 @@ type LineItem struct {
 
 // Contact defines a single contact
 type Contact struct {
-	Company     string `json:"customer"`
+	Company     string `json:"company"`
 	Address1    string `json:"address1"`
 	Address2    string `json:"address2"`
 	City        string `json:"city"`

--- a/segments.go
+++ b/segments.go
@@ -23,7 +23,7 @@ type SegmentRequest struct {
 type Segment struct {
 	SegmentRequest
 
-	ID          int    `json:"id"`
+	ID          string    `json:"id"`
 	MemberCount int    `json:"member_count"`
 	Type        string `json:"type"`
 	CreatedAt   string `json:"created_at"`


### PR DESCRIPTION
In **common_types.go**,  the Contact struct has a Company attribute which has the wrong json label. Currently it is **json:customer**, it now is **json:company**. This allows the proper creation of lists via the CreateList command now. 

Really helpful client by the way! 