### PR TITLE
Omit empty merge field choices array to pass API validation

### DIFF
--- a/lists.go
+++ b/lists.go
@@ -577,7 +577,7 @@ type MergeFieldOptions struct {
 	DefaultCountry int      `json:"default_Country"`
 	PhoneFormat    string   `json:"phone_format"`
 	DateFormat     string   `json:"date_format"`
-	Choices        []string `json:"choices"`
+	Choices        []string `json:"choices,omitempty"`
 	Size           int      `json:"size"`
 }
 


### PR DESCRIPTION
Currently it is not possible to create new merge fields that are not options as the Mailchimp API does not accept `null` as an empty array, however it is possible to omit the field and pass validation.

Consider the struct:

```go
gochimp3.MergeField{
  Tag: "My example field",
  Type: "text",
}
```

Will be encoded by `json.Marshal` as: 

```json
{
  "tag": "",
  "name": "My example field",
  "type": "text",
  "required": false,
  "default_value": "",
  "public": false,
  "display_order": 0,
  "options": {
    "default_Country": 0,
    "phone_format": "",
    "date_format": "",
    "choices": null,
    "size": 0
  },
  "help_text": ""
}
```

However Mailchimp will reject this request with an error, as `choices` is `null` rather than an empty array: `[]`:

> Invalid Resource : The resource submitted could not be validated. For field-specific details, see the 'errors' array. : [{options.choices Schema describes array, NULL found instead}]

There is an open issue on Go discussing the options for encoding as an empty array instead of null - golang/go#27589 - but in the meantime it is possible to omit the empty `choices` field and Mailchimp will create the merge field as expected.
