### PR TITLE
Make `recipients.segment_opts` optional in campaign creation request 

### DIFF
--- a/campaigns.go
+++ b/campaigns.go
@@ -68,7 +68,7 @@ type ListOfCampaigns struct {
 
 type CampaignCreationRecipients struct {
 	ListId string `json:"list_id"`
-	SegmentOptions CampaignCreationSegmentOptions `json:"segment_opts"`
+	SegmentOptions *CampaignCreationSegmentOptions `json:"segment_opts,omitempty"`
 }
 
 type CampaignCreationSegmentOptions struct {

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
`recipients.segment_opts` in MailChimp API docs is optional, hence I have modified the `CampaignCreationSegmentOptions` accordingly

My use case is that I have to send emails to all members of a preexisting list (maintained by my service)