### PR TITLE
Fix BatchSubscribeMembers Response

### DIFF
--- a/lists.go
+++ b/lists.go
@@ -507,8 +507,8 @@ type BatchSubscribeMembersError struct {
 type BatchSubscribeMembersResponse struct {
 	withLinks
 
-	NewMembers     []ListOfMembers              `json:"new_members"`
-	UpdatedMembers []ListOfMembers              `json:"updated_members"`
+	NewMembers     []Member                     `json:"new_members"`
+	UpdatedMembers []Member                     `json:"updated_members"`
 	ErrorMessages  []BatchSubscribeMembersError `json:"errors"`
 	TotalCreated   int                          `json:"total_created"`
 	TotalUpdated   int                          `json:"total_updated"`


### PR DESCRIPTION
Seems like the BatchSubscribeMembers response JSON returns an array of Members - tested it myself and seems to work if the type is a `[]Member`.