### PR TITLE
Fixed Segment Id type

### DIFF
--- a/segments.go
+++ b/segments.go
@@ -23,7 +23,7 @@ type SegmentRequest struct {
 type Segment struct {
 	SegmentRequest
 
-	ID          string    `json:"id"`
+	ID          int    `json:"id"`
 	MemberCount int    `json:"member_count"`
 	Type        string `json:"type"`
 	CreatedAt   string `json:"created_at"`


### PR DESCRIPTION
The response to `GetSegment` defines `ID` as an `Int` not a `String` as per https://mailchimp.com/developer/marketing/api/list-segments/get-segment-info/

The current `struct` definition results in an error when calling `list.GetSegment`:

`json: cannot unmarshal number into Go struct field Segment.id of type string`