### PR TITLE
Made the segment options optional for CampaignCreationRecipients

### DIFF
--- a/campaigns.go
+++ b/campaigns.go
@@ -6,20 +6,20 @@ import (
 )
 
 const (
-	campaigns_path       = "/campaigns"
-	single_campaign_path = campaigns_path + "/%s"
+	campaigns_path        = "/campaigns"
+	single_campaign_path  = campaigns_path + "/%s"
 	campaign_content_path = single_campaign_path + "/content"
 
 	send_test_path = single_campaign_path + "/actions/test"
-	send_path = single_campaign_path + "/actions/send"
+	send_path      = single_campaign_path + "/actions/send"
 
-	CAMPAIGN_TYPE_REGULAR = "regular"
+	CAMPAIGN_TYPE_REGULAR   = "regular"
 	CAMPAIGN_TYPE_PLAINTEXT = "plaintext"
-	CAMPAIGN_TYPE_ABSPLIT = "absplit" // deprecated by mailchimp
-	CAMPAIGN_TYPE_RSS = "rss"
-	CAMPAIGN_TYPE_VARIATE = "variate"
+	CAMPAIGN_TYPE_ABSPLIT   = "absplit" // deprecated by mailchimp
+	CAMPAIGN_TYPE_RSS       = "rss"
+	CAMPAIGN_TYPE_VARIATE   = "variate"
 
-	CAMPAIGN_SEND_TYPE_HTML = "html"
+	CAMPAIGN_SEND_TYPE_HTML      = "html"
 	CAMPAIGN_SEND_TYPE_PLAINTEXT = "plaintext"
 
 	CONDITION_MATCH_ANY = "any"
@@ -30,20 +30,19 @@ const (
 	CONDITION_OP_CONTAINS = "interestcontains"
 )
 
-
 type CampaignQueryParams struct {
 	ExtendedQueryParams
 
-	Type string
-	Status string
-	BeforeSendTime string
-	SinceSendTime string
+	Type             string
+	Status           string
+	BeforeSendTime   string
+	SinceSendTime    string
 	BeforeCreateTime string
-	SinceCreateTime string
-	ListId string
-	FolderId string
-	SortField string
-	SortDir string
+	SinceCreateTime  string
+	ListId           string
+	FolderId         string
+	SortField        string
+	SortDir          string
 }
 
 func (q CampaignQueryParams) Params() map[string]string {
@@ -67,23 +66,23 @@ type ListOfCampaigns struct {
 }
 
 type CampaignCreationRecipients struct {
-	ListId string `json:"list_id"`
-	SegmentOptions CampaignCreationSegmentOptions `json:"segment_opts"`
+	ListId         string                          `json:"list_id"`
+	SegmentOptions *CampaignCreationSegmentOptions `json:"segment_opts,omitempty"`
 }
 
 type CampaignCreationSegmentOptions struct {
-	SavedSegmentId int `json:"saved_segment_id"`
-	Match      string               `json:"match"`		// one of CONDITION_MATCH_*
+	SavedSegmentId int    `json:"saved_segment_id"`
+	Match          string `json:"match"` // one of CONDITION_MATCH_*
 
 	// this accepts various payloads. See http://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/#create-post_campaigns
 	Conditions interface{} `json:"conditions"`
 }
 
 type InterestsCondition struct {
-	ConditionType string `json:"condition_type"`
-	Field string `json:"field"`
-	Op    string `json:"op"`
-	Value []string `json:"value"`
+	ConditionType string   `json:"condition_type"`
+	Field         string   `json:"field"`
+	Op            string   `json:"op"`
+	Value         []string `json:"value"`
 }
 
 type CampaignCreationSettings struct {
@@ -92,32 +91,32 @@ type CampaignCreationSettings struct {
 	Title           string `json:"title"`
 	FromName        string `json:"from_name"`
 	ReplyTo         string `json:"reply_to"`
-	UseConversation bool `json:"use_conversation"`
+	UseConversation bool   `json:"use_conversation"`
 	ToName          string `json:"to_name"`
 	FolderId        string `json:"folder_id"`
-	Authenticate    bool `json:"authenticate"`
-	AutoFooter      bool `json:"auto_footer"`
-	InlineCss       bool `json:"inline_css"`
-	AutoTweet       bool `json:"auto_tweet"`
-	FbComments      bool `json:"fb_comments"`
-	TemplateId      uint `json:"template_id"`
+	Authenticate    bool   `json:"authenticate"`
+	AutoFooter      bool   `json:"auto_footer"`
+	InlineCss       bool   `json:"inline_css"`
+	AutoTweet       bool   `json:"auto_tweet"`
+	FbComments      bool   `json:"fb_comments"`
+	TemplateId      uint   `json:"template_id"`
 }
 
 type CampaignCreationRequest struct {
-	Type       string           `json:"type"` // must be one of the CAMPAIGN_TYPE_* consts
+	Type       string                     `json:"type"` // must be one of the CAMPAIGN_TYPE_* consts
 	Recipients CampaignCreationRecipients `json:"recipients"`
-	Settings   CampaignCreationSettings `json:"settings"`
+	Settings   CampaignCreationSettings   `json:"settings"`
 	// variate_settings not implemented
-	Tracking          CampaignTracking `json:"tracking"`
+	Tracking CampaignTracking `json:"tracking"`
 	// rss_opts not implemented
 	// social_card not implemented
 }
 
 type CampaignResponseRecipients struct {
-	ListId string `json:"list_id"`
-	ListName string `json:"list_name"`
-	SegmentText string `json:"segment_text"`
-	RecipientCount int `json:"recipient_count"`
+	ListId         string `json:"list_id"`
+	ListName       string `json:"list_name"`
+	SegmentText    string `json:"segment_text"`
+	RecipientCount int    `json:"recipient_count"`
 }
 
 type CampaignResponseSettings struct {
@@ -126,25 +125,25 @@ type CampaignResponseSettings struct {
 	Title           string `json:"title"`
 	FromName        string `json:"from_name"`
 	ReplyTo         string `json:"reply_to"`
-	UseConversation bool `json:"use_conversation"`
+	UseConversation bool   `json:"use_conversation"`
 	ToName          string `json:"to_name"`
 	FolderId        string `json:"folder_id"`
-	Authenticate    bool `json:"authenticate"`
-	AutoFooter      bool `json:"auto_footer"`
-	InlineCss       bool `json:"inline_css"`
-	AutoTweet       bool `json:"auto_tweet"`
-	FbComments      bool `json:"fb_comments"`
-	Timewarp        bool `json:"timewarp"`
-	TemplateId      uint `json:"template_id"`
-	DragAndDrop     bool `json:"drag_and_drop"`
+	Authenticate    bool   `json:"authenticate"`
+	AutoFooter      bool   `json:"auto_footer"`
+	InlineCss       bool   `json:"inline_css"`
+	AutoTweet       bool   `json:"auto_tweet"`
+	FbComments      bool   `json:"fb_comments"`
+	Timewarp        bool   `json:"timewarp"`
+	TemplateId      uint   `json:"template_id"`
+	DragAndDrop     bool   `json:"drag_and_drop"`
 }
 
 type CampaignTracking struct {
-	Opens           bool `json:"opens"`
-	HtmlClicks      bool `json:"html_clicks"`
-	TextClicks      bool `json:"text_clicks"`
-	GoalTracking    bool `json:"goal_tracking"`
-	Ecomm360        bool `json:"ecomm360"`
+	Opens           bool   `json:"opens"`
+	HtmlClicks      bool   `json:"html_clicks"`
+	TextClicks      bool   `json:"text_clicks"`
+	GoalTracking    bool   `json:"goal_tracking"`
+	Ecomm360        bool   `json:"ecomm360"`
 	GoogleAnalytics string `json:"google_analytics"`
 	Clicktale       string `json:"clicktale"`
 }
@@ -156,38 +155,38 @@ type CampaignEcommerce struct {
 }
 
 type CampaignReportSummary struct {
-	Opens            int `json:"opens"`
-	UniqueOpens      int `json:"unique_opens"`
-	OpenRate         float32 `json:"open_rate"`
-	Clicks           int `json:"clicks"`
-	SubscriberClicks int `json:"subscriber_clicks"`
-	ClickRate        float32 `json:"click_rate"`
+	Opens            int               `json:"opens"`
+	UniqueOpens      int               `json:"unique_opens"`
+	OpenRate         float32           `json:"open_rate"`
+	Clicks           int               `json:"clicks"`
+	SubscriberClicks int               `json:"subscriber_clicks"`
+	ClickRate        float32           `json:"click_rate"`
 	Ecommerce        CampaignEcommerce `json:"ecommerce"`
 }
 
 type CampaignDeliveryStatus struct {
-	Enabled  		 bool `json:"enabled"`
+	Enabled bool `json:"enabled"`
 }
 
 type CampaignResponse struct {
 	withLinks
 
-	ID                string `json:"id"`
-	WebID             uint   `json:"web_id"`
-	Type              string `json:"type"`
-	CreateTime        string `json:"create_time"`
-	ArchiveUrl        string `json:"archive_url"`
-	LongArchiveUrl    string `json:"long_archive_url"`
-	Status            string `json:"status"`
-	EmailsSent        uint   `json:"emails_sent"`
-	SendTime          string `json:"send_time"`
-	ContentType       string `json:"content_type"`
-	NeedsBlockRefresh bool   `json:"needs_block_refresh"`
+	ID                string                     `json:"id"`
+	WebID             uint                       `json:"web_id"`
+	Type              string                     `json:"type"`
+	CreateTime        string                     `json:"create_time"`
+	ArchiveUrl        string                     `json:"archive_url"`
+	LongArchiveUrl    string                     `json:"long_archive_url"`
+	Status            string                     `json:"status"`
+	EmailsSent        uint                       `json:"emails_sent"`
+	SendTime          string                     `json:"send_time"`
+	ContentType       string                     `json:"content_type"`
+	NeedsBlockRefresh bool                       `json:"needs_block_refresh"`
 	Recipients        CampaignResponseRecipients `json:"recipients"`
-	Settings          CampaignResponseSettings `json:"settings"`
-	Tracking          CampaignTracking `json:"tracking"`
-	ReportSummary     CampaignReportSummary `json:"report_summary"`
-	DeliveryStatus    CampaignDeliveryStatus `json:"delivery_status"`
+	Settings          CampaignResponseSettings   `json:"settings"`
+	Tracking          CampaignTracking           `json:"tracking"`
+	ReportSummary     CampaignReportSummary      `json:"report_summary"`
+	DeliveryStatus    CampaignDeliveryStatus     `json:"delivery_status"`
 
 	api *API
 }
@@ -250,11 +249,11 @@ func (api *API) DeleteCampaign(id string) (bool, error) {
 
 type TestEmailRequest struct {
 	TestEmails []string `json:"test_emails"`
-	SendType	string	`json:"send_type"`	// one of the CAMPAIGN_SEND_TYPE_* constants
+	SendType   string   `json:"send_type"` // one of the CAMPAIGN_SEND_TYPE_* constants
 }
 
 type SendCampaignRequest struct {
-	CampaignId	string	`json:"campaign_id"`
+	CampaignId string `json:"campaign_id"`
 }
 
 func (api *API) SendTestEmail(id string, body *TestEmailRequest) (bool, error) {
@@ -277,31 +276,29 @@ func (api *API) SendCampaign(id string, body *SendCampaignRequest) (bool, error)
 	return true, nil
 }
 
-
 // ------------------------------------------------------------------------------------------------
 // Campaign Content Updates
 // ------------------------------------------------------------------------------------------------
 
-
 type CampaignContentTemplateRequest struct {
-	ID uint `json:"id,omitempty"`
+	ID       uint              `json:"id,omitempty"`
 	Sections map[string]string `json:"sections,omitempty"`
 }
 
 type CampaignContentUpdateRequest struct {
-	PlainText string `json:"plain_text"`
-	Html string `json:"html"`
-	Url string `json:"url"`
-	Template *CampaignContentTemplateRequest `json:"template,omitempty"`
+	PlainText string                          `json:"plain_text"`
+	Html      string                          `json:"html"`
+	Url       string                          `json:"url"`
+	Template  *CampaignContentTemplateRequest `json:"template,omitempty"`
 }
 
 type CampaignContentResponse struct {
 	withLinks
 
-	PlainText string `json:"plain_text"`
-	Html string `json:"html"`
+	PlainText   string `json:"plain_text"`
+	Html        string `json:"html"`
 	ArchiveHtml string `json:"archive_html"`
-	api *API
+	api         *API
 }
 
 func (api *API) GetCampaignContent(id string, params *BasicQueryParams) (*CampaignContentResponse, error) {


### PR DESCRIPTION
Used a pointer to represent the CampaignCreationSegmentOptions and marked it as omitempty. This is neccessary for a functional campaign with no segments to be created