### PR TITLE
make CampaignCreationSegmentOptions fields omitempty

### DIFF
--- a/campaigns.go
+++ b/campaigns.go
@@ -72,11 +72,11 @@ type CampaignCreationRecipients struct {
 }
 
 type CampaignCreationSegmentOptions struct {
-	SavedSegmentId int `json:"saved_segment_id"`
-	Match      string               `json:"match"`		// one of CONDITION_MATCH_*
+	SavedSegmentId int `json:"saved_segment_id,omitempty"`
+	Match      string               `json:"match,omitempty"`		// one of CONDITION_MATCH_*
 
 	// this accepts various payloads. See http://developer.mailchimp.com/documentation/mailchimp/reference/campaigns/#create-post_campaigns
-	Conditions interface{} `json:"conditions"`
+	Conditions interface{} `json:"conditions,omitempty"`
 }
 
 type InterestsCondition struct {


### PR DESCRIPTION
`recipients.segment_opts` in MailChimp API docs is optional, hence I have modified the `CampaignCreationSegmentOptions` struct accordingly.

I did not like the solution in #53 and #60 which makes `SegmentOptions` a pointer because it is breaking change. However that is the only way to use the `omitempty` tag on a struct field.

My solution is to instead place `omitempty` on all the fields within the struct. When the `CampaignCreationRecipients` is JSON marshalled and `SegmentOptions` is not provided, it will generate `"segment_opts": {}` which behaves the same at it being omitted in the MailChimp API. This solution also does not break existing usage.